### PR TITLE
Add the auto_ip functionality back

### DIFF
--- a/playbooks/hortonworks/cluster_vars.yaml.example-complex
+++ b/playbooks/hortonworks/cluster_vars.yaml.example-complex
@@ -8,6 +8,7 @@ bastion_secgroup: "bastion"
 master:
   inventory_group: masters
   auto_ip: yes
+  # floating_ip: 1.2.3.4
   flavor: "standard.large"
 
   # Here we list the block devices. A LVM volume group is created per device.

--- a/playbooks/hortonworks/cluster_vars.yaml.example-io-flavor
+++ b/playbooks/hortonworks/cluster_vars.yaml.example-io-flavor
@@ -7,6 +7,7 @@ bastion_secgroup: "bastion"
 master:
   inventory_group: masters
   auto_ip: yes
+  # floating_ip: 1.2.3.4
   flavor: "standard.large"
   volumes:
     - name: metadata

--- a/playbooks/hortonworks/provision.yml
+++ b/playbooks/hortonworks/provision.yml
@@ -43,6 +43,18 @@
       loop_control:
         loop_var: "vm_group_name"
 
+    - name: assign selected public ip to master
+      os_floating_ip:
+        server: "{{ cluster_name }}-master-1"
+        floating_ip_address: "{{ master.floating_ip }}"
+      when: master.floating_ip is defined
+
+    - name: auto-assign floating ip
+      os_floating_ip:
+        server: "{{ cluster_name }}-master-1"
+        reuse: yes
+      when: (master.auto_ip|default(false))|bool and master.floating_ip is not defined
+
     - name: provision nodes
       include: tasks/vm_group_provision.yml
       with_items: "{{ node_groups }}"


### PR DESCRIPTION
- added automatic master floating ip assignment (it was accidentally removed during refactoring)
- also added an option to assign a predetermined floating ip
- updated cluster_var.yaml examples

Thanks for Aleksander Agafonov for bug report