### PR TITLE
Fixes/provisioning

### DIFF
--- a/playbooks/common/wait_for_ssh.yml
+++ b/playbooks/common/wait_for_ssh.yml
@@ -12,7 +12,7 @@
       delegate_to: 127.0.0.1
 
     - name: wait for ssh to work
-      shell: ssh -q {{ ansible_ssh_user }}@{{ ansible_ssh_host }} 'echo success'
+      shell: ssh -o PasswordAuthentication=no -q {{ ansible_ssh_user }}@{{ ansible_ssh_host }} 'echo success'
       register: result
       until: result.stdout.find('success') != -1
       retries: 30

--- a/roles/cluster_master/tasks/main.yml
+++ b/roles/cluster_master/tasks/main.yml
@@ -8,9 +8,6 @@
   with_items: "{{ groups['all'] }}"
   notify: restart_dnsmasq
 
-- name: install pdsh
-  yum: name=pdsh state=present
-
 # http://developerblog.redhat.com/2015/11/19/dns-your-openshift-v3-cluster/
 - name: install dnsmasq
   yum: name=dnsmasq state=present
@@ -26,3 +23,6 @@
     line: "-A INPUT -p udp -m udp --dport 53 -j ACCEPT"
     dest: /etc/sysconfig/iptables
     insertbefore: '^-A INPUT'
+
+- name: install pdsh
+  yum: name=pdsh state=present

--- a/tasks/vm_group_volume_deprovision.yml
+++ b/tasks/vm_group_volume_deprovision.yml
@@ -4,6 +4,17 @@
   os_volume:
     display_name: "{{ cluster_name }}-{{ vm_group_name }}-{{ item }}-{{ volume_spec.name }}"
     state: absent
-    wait: no
+    wait: yes
   with_sequence: count={{ vm_group.num_vms|default(1) }}
+  async: 300
+  register: async_volume_remove
+  when: "{{ volume_spec.size }}|default(0) > 0"
+
+- name: check volume remove status
+  async_status: jid={{ item.ansible_job_id }}
+  register: job_result
+  until: job_result.finished
+  retries: 30
+  delay: 15
+  with_items: "{{ async_volume_remove.results }}"
   when: "{{ volume_spec.size }}|default(0) > 0"


### PR DESCRIPTION
* asynchronously wait for volume deletion, so reprovisioning can be run right after deprovisioning has finished
* start internal DNS before package installations
* add an option to disable password authentication. Testing for connectivity is not an interactive situation, so public key should work and no prompts should be present
