### PR TITLE
ssh config aliases

### DIFF
--- a/tasks/vm_group_deprovision.yml
+++ b/tasks/vm_group_deprovision.yml
@@ -25,3 +25,10 @@
   loop_control:
     loop_var: "volume_spec"
   when: remove_volumes | bool
+
+- name: remove ssh config entries
+  blockinfile:
+    dest: "{{ ansible_env.HOME }}/.ssh/config"
+    state: absent
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}-{{ vm_group_name }}-{{ item }}"
+  with_sequence: count={{ vm_group.num_vms|default(1) }}

--- a/tasks/vm_group_provision.yml
+++ b/tasks/vm_group_provision.yml
@@ -57,3 +57,16 @@
   with_items: "{{ vm_group_volumes }}"
   loop_control:
     loop_var: "volume_spec"
+
+- name: add ssh config entries
+  blockinfile:
+    create: yes
+    mode: '0600'
+    dest: "{{ ansible_env.HOME }}/.ssh/config"
+    block: |
+      Host {{ item.name }} {{ item.private_v4 }}
+          Hostname {{ item.private_v4 }}
+          StrictHostKeyChecking no
+          UserKnownHostsFile /dev/null
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.name }}"
+  with_items: "{{ openstack_servers|sort(attribute='name') }}"


### PR DESCRIPTION
- aliases for VMs are managed in .ssh/config for easier access
- created when provisioning, removed when deprovisioning
- StrictHostKeyChecking is disabled for managed hosts