### PR TITLE
general provisioning enhancements

### DIFF
--- a/playbooks/hortonworks/README.md
+++ b/playbooks/hortonworks/README.md
@@ -91,14 +91,14 @@ In this step we launch VMs in our cPouta project and configure them to act as a 
 for a simple cluster. You can run this on your management host, be it the bastion or your
 laptop.
 
-Make a python virtualenv called 'ansible-2.1' and populate it
+Make a python virtualenv called 'ansible-2.2' and populate it
 
-    mkvirtualenv --system-site-packages ansible2
-    pip install --upgrade pip setuptools
-    pip install ansible==2.1
+    mkvirtualenv --system-site-packages ansible-2.2
+    pip install --upgrade pip
+    pip install 'ansible<2.3'
     pip install shade dnspython funcsigs functools32
 
-You can activate it later with the command 'workon ansible-2.1'
+You can activate it later with the command 'workon ansible-2.2'
 
 Source your OpenStack cPouta access credentials (actual filename will vary) and check that they work by listing
 the VM images
@@ -114,24 +114,6 @@ Create a new key (if don't already have one) for the cluster (adapt the name) an
 Clone this example repo
 
     git clone https://github.com/CSC-IT-Center-for-Science/pouta-ansible-cluster.git
-
-Disable ssh host key checking (http://docs.ansible.com/ansible/intro_getting_started.html#host-key-checking).
-Add an entry for all the hosts in your cPouta subnet. Use *ip* command to figure out your network address range.
-Also adapt the IdentityFile -line to match the key you have generated.
-    
-    ip a
-    
-    vi ~/.ssh/config
-    
-    Host XX.XX.XX.*
-
-        StrictHostKeyChecking no
-        IdentitiesOnly yes
-        IdentityFile ~/.ssh/id_rsa_mycluster
-        
-Change the permissions on the config file
-
-    chmod 600 ~/.ssh/config
 
 ### Optional step: server group for node anti-affinity
 
@@ -163,7 +145,7 @@ For example, to provision a test cluster with master and four small nodes, take 
 
 ### Run provisioning
 
-Make sure you have ansible-2.1 virtual environment and openstack credentials loaded. 
+Make sure you have ansible-2.2 virtual environment and openstack credentials loaded. 
 
 Then, provision the VMs and associated resources
 

--- a/playbooks/hortonworks/provision.yml
+++ b/playbooks/hortonworks/provision.yml
@@ -68,7 +68,7 @@
     - name: create inventory on disk
       template:
         src: templates/hortonworks-inventory.j2
-        dest: ./hortonworks-inventory
+        dest: "{{ ansible_env.HOME }}/{{ cluster_name }}/hortonworks-inventory"
         backup: yes
 
     - name: create tmuxinator status session config

--- a/roles/ambari_server/handlers/main.yml
+++ b/roles/ambari_server/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart iptables
+  service: name=iptables state=restarted

--- a/roles/ambari_server/tasks/main.yml
+++ b/roles/ambari_server/tasks/main.yml
@@ -34,3 +34,10 @@
 
 - name: start ambari service
   service: name=ambari-server state=running enabled=yes
+
+- name: allow access to ambari
+  lineinfile:
+    line: "-A INPUT -p tcp -m state --state NEW -m tcp --dport 8080 -j ACCEPT"
+    dest: /etc/sysconfig/iptables
+    insertbefore: '^-A INPUT -j REJECT --reject-with icmp-host-prohibited'
+  notify: restart iptables

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -16,6 +16,8 @@
     - lvm2
     - chrony
     - bzip2
+    - iptables
+    - iptables-services
 
 - name: stop cloud-init managing /etc/hosts
   lineinfile:

--- a/roles/cluster_common/templates/etc/sysconfig/iptables.j2
+++ b/roles/cluster_common/templates/etc/sysconfig/iptables.j2
@@ -6,7 +6,7 @@
 -A INPUT -p icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
--A INPUT -p tcp -m state --state NEW -m tcp --dport 2049 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp-host-prohibited
 -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
 COMMIT

--- a/roles/cluster_master/tasks/main.yml
+++ b/roles/cluster_master/tasks/main.yml
@@ -20,9 +20,12 @@
 
 - name: open ports 53 for DNS
   lineinfile:
-    line: "-A INPUT -p udp -m udp --dport 53 -j ACCEPT"
+    line: "-A INPUT -p {{ item }} -m {{ item }} --dport 53 -j ACCEPT"
     dest: /etc/sysconfig/iptables
     insertbefore: '^-A INPUT'
+  with_items:
+    - udp
+    - tcp
 
 - name: install pdsh
   yum: name=pdsh state=present

--- a/roles/hortonworks_common/handlers/main.yml
+++ b/roles/hortonworks_common/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart iptables
+  service: name=iptables state=restarted

--- a/roles/hortonworks_common/tasks/main.yml
+++ b/roles/hortonworks_common/tasks/main.yml
@@ -9,3 +9,10 @@
     regexp: '^securerandom.source.*'
     line: 'securerandom.source=file:/dev/urandom'
     state: present
+
+- name: open all TCP traffic (actual control done with security rules)
+  lineinfile:
+    line: "-A INPUT -p tcp -m state --state NEW -m tcp -j ACCEPT"
+    dest: /etc/sysconfig/iptables
+    insertbefore: '^-A INPUT -j REJECT --reject-with icmp-host-prohibited'
+  notify: restart iptables

--- a/roles/nfs_server/handlers/main.yml
+++ b/roles/nfs_server/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: restart nfs-server
   service: name=nfs-server state=restarted
+
+- name: restart iptables
+  service: name=iptables state=restarted

--- a/roles/nfs_server/tasks/main.yml
+++ b/roles/nfs_server/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: allow access to NFSv4
+  lineinfile:
+    line: "-A INPUT -p tcp -m state --state NEW -m tcp --dport 2049 -j ACCEPT"
+    dest: /etc/sysconfig/iptables
+    insertbefore: '^-A INPUT -j REJECT --reject-with icmp-host-prohibited'
+  notify: restart iptables
+
 - name: install NFS server packages
   yum:
     name: nfs-utils
@@ -18,5 +25,5 @@
     dest: /etc/exports
     regexp: "^{{ item.directory }} "
     line: "{{ item.directory }} {{ item.export_options | default(cluster_name+'*(rw)') }}"
-  with_items: "{{ exports }}"
+  with_items: "{{ exports|default([]) }}"
   notify: restart nfs-server

--- a/tasks/create_tmuxinator_config.yml
+++ b/tasks/create_tmuxinator_config.yml
@@ -1,13 +1,11 @@
 ---
-- set_fact: local_home="{{ lookup('env','HOME') }}"
-
 - name: create .tmuxinator.yaml on disk
   template:
     src: templates/tmuxinator_status.yml.j2
-    dest: ./.tmuxinator.yml
+    dest: "{{ ansible_env.HOME }}/{{ cluster_name }}/.tmuxinator.yml"
 
 - name: create .tmux.conf on disk
   template:
     backup: yes
     src: templates/tmux.conf.j2
-    dest: "{{ local_home }}/.tmux.conf"
+    dest: "{{ ansible_env.HOME }}/.tmux.conf"


### PR DESCRIPTION
- support for Ansible 2.2
  - relative paths for creating inventory do not work anymore, switched to using HOME
- iptables installed and activated by default
- $HOME/.ssh/config is populated with provisioned VMs, providing aliases
- hortonworks README updated